### PR TITLE
fix: skip prepare script during docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 COPY package*.json ./
-RUN npm ci
+RUN npm ci --ignore-scripts
 
 COPY tsconfig.json ./
 COPY src/ ./src/


### PR DESCRIPTION
## Summary
- Add `--ignore-scripts` to `npm ci` in Dockerfile to prevent the `prepare` script from running before source files are copied