### PR TITLE
refactor: rename package from shellwright-mcp-server to shellwright

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ Shellwright is an MCP server providing "Playwright for the shell" - enabling AI 
 ## Project Structure
 
 ```
-shellwright-mcp-server/
+shellwright/
 ├── src/                    # TypeScript source code
 │   └── index.ts           # MCP server entry point
 ├── examples/              # Demo scripts

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@
     <a href="#configuration">Configuration</a>
   </p>
   <p align="center">
-    <a href="https://github.com/dwmkerr/shellwright-mcp-server/actions/workflows/cicd.yaml"><img src="https://github.com/dwmkerr/shellwright-mcp-server/actions/workflows/cicd.yaml/badge.svg" alt="cicd"></a>
-    <a href="https://www.npmjs.com/package/@dwmkerr/shellwright-mcp-server"><img src="https://img.shields.io/npm/v/@dwmkerr/shellwright-mcp-server" alt="npm version"></a>
+    <a href="https://github.com/dwmkerr/shellwright/actions/workflows/cicd.yaml"><img src="https://github.com/dwmkerr/shellwright/actions/workflows/cicd.yaml/badge.svg" alt="cicd"></a>
+    <a href="https://www.npmjs.com/package/@dwmkerr/shellwright"><img src="https://img.shields.io/npm/v/@dwmkerr/shellwright" alt="npm version"></a>
   </p>
 </p>
 
@@ -29,7 +29,7 @@ Configure your LLM, IDE or whatever to use the Shellwright MCP server:
   "mcpServers": {
     "shellwright": {
       "command": "npx",
-      "args": ["-y", "@dwmkerr/shellwright-mcp-server"]
+      "args": ["-y", "@dwmkerr/shellwright"]
     }
   }
 }

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1,7 +1,7 @@
 replicaCount: 1
 
 image:
-  repository: ghcr.io/dwmkerr/shellwright-mcp-server
+  repository: ghcr.io/dwmkerr/shellwright
   pullPolicy: IfNotPresent
   tag: ""  # Defaults to appVersion
 

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -2,7 +2,7 @@ version: v2beta1
 name: shellwright
 
 vars:
-  IMAGE: ghcr.io/dwmkerr/shellwright-mcp-server
+  IMAGE: ghcr.io/dwmkerr/shellwright
 
 images:
   shellwright:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@dwmkerr/shellwright-mcp-server",
+  "name": "@dwmkerr/shellwright",
   "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@dwmkerr/shellwright-mcp-server",
+      "name": "@dwmkerr/shellwright",
       "version": "0.1.2",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@dwmkerr/shellwright-mcp-server",
+  "name": "@dwmkerr/shellwright",
   "version": "0.1.2",
   "type": "module",
   "description": "Playwright for the shell - MCP server for terminal recording and automation",
@@ -19,12 +19,12 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/dwmkerr/shellwright-mcp-server.git"
+    "url": "git+https://github.com/dwmkerr/shellwright.git"
   },
   "bugs": {
-    "url": "https://github.com/dwmkerr/shellwright-mcp-server/issues"
+    "url": "https://github.com/dwmkerr/shellwright/issues"
   },
-  "homepage": "https://github.com/dwmkerr/shellwright-mcp-server#readme",
+  "homepage": "https://github.com/dwmkerr/shellwright#readme",
   "keywords": [
     "mcp",
     "terminal",


### PR DESCRIPTION
## Summary
- Rename npm package from `@dwmkerr/shellwright-mcp-server` to `@dwmkerr/shellwright`
- Update all repository URLs and references
- Update Docker image references in devspace.yaml and chart/values.yaml

Note: After merging, publish new package to npm and deprecate the old one.