### PR TITLE
docs: fix README image syntax and remove TODO section

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Use [`htop`](https://github.com/htop-dev/htop):
 
 > Open vim, create validate.py that checks if arguments are UK postcodes. Print ✓ or ✗ for each. Then run: python3 validate.py on a set of UK postcodes (valid and invalid) such as "SW1A 1AA" "INVALID" "M1 1AA". Record as a video. Take 2-3 screenshots along the way.
 
-[!Screenshot: Example - UK Postcode Validation](./docs/examples/postcode.gif)
+![Screenshot: Example - UK Postcode Validation](./docs/examples/postcode.gif)
 
 ## Configuration
 
@@ -358,13 +358,6 @@ Install locally for Claude Code:
 ```bash
 claude mcp add --transport stdio shellwright-dev --scope project -- npm --prefix "${PWD}" start
 ```
-
-## TODO
-
-Ideas for the future.
-
-- Video export (MP4/MOV) via ffmpeg
-- Better logging, a bit like `hl`
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build": "tsc",
     "start": "node dist/index.js",
     "dev": "tsx watch src/index.ts",
-    "dev:http": "tsx watch src/index.ts --http",
+    "dev:http": "tsx watch src/index.ts --http --log-path log.jsonl",
     "test": "jest",
     "test:emulator": "tsx tests/run-tests.ts",
     "test:k9s": "tsx tests/04-k9s/run.ts",


### PR DESCRIPTION
## Summary
- Fix postcode.gif markdown image syntax (`[!` → `![`)
- Remove TODO section (moved to GitHub issue #25)
- Add `--log-path` to dev:http script for debugging