### PR TITLE
docs: improve shell_start parameter descriptions for login shells

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -201,8 +201,18 @@ const createServer = (getMcpSessionId: () => string | undefined) => {
     "shell_start",
     "Start a new PTY session with a command",
     {
-      command: z.string().describe("Command to run (e.g., 'k9s', 'bash')"),
-      args: z.array(z.string()).optional().describe("Command arguments"),
+      command: z.string().describe(
+        "Command to run. Examples: 'bash', 'zsh', 'k9s', 'htop', 'vim'. " +
+        "For interactive shell sessions that should match the user's normal terminal " +
+        "(custom prompt, colors, aliases, PATH), use 'bash' or 'zsh' with args ['--login', '-i']. " +
+        "For standalone TUI programs like k9s, htop, or vim, run the command directly without shell flags."
+      ),
+      args: z.array(z.string()).optional().describe(
+        "Command arguments. For interactive shells (bash, zsh), use ['--login', '-i'] to source " +
+        "the user's shell configuration (~/.bashrc, ~/.zshrc) which provides their custom prompt, " +
+        "aliases, functions, and environment variables. Without these flags, shells start with a " +
+        "minimal environment and basic prompt. Not needed for standalone programs like k9s or htop."
+      ),
       cols: z.number().optional().describe(`Terminal columns (default: ${COLS})`),
       rows: z.number().optional().describe(`Terminal rows (default: ${ROWS})`),
     },


### PR DESCRIPTION
## Summary

- Update `command` and `args` parameter descriptions to guide LLMs on using `--login -i` flags

When recording shell sessions, LLMs need to know to use `bash --login -i` or `zsh --login -i` to get the user's normal terminal environment (custom PS1, colors, aliases, PATH).

Without this guidance, shells start with minimal environment and the recorded output doesn't match what users see in their own terminal.

**Before:** `"Command to run (e.g., 'k9s', 'bash')"`

**After:** Detailed description explaining when and why to use login shell flags.