### PR TITLE
feat: shell_screenshot returns png_url and svg_url

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -202,7 +202,7 @@ Tips:
 
   server.tool(
     "shell_screenshot",
-    "Capture terminal screenshot as PNG. Returns a download_url - use curl to save the file locally (e.g., curl -o screenshot.png <url>)",
+    "Capture terminal screenshot as PNG and SVG. Returns png_url and svg_url - use curl to save (e.g., curl -o screenshot.png <png_url>)",
     shellScreenshotSchema,
     async (params) => shellScreenshot(params, toolContext)
   );

--- a/src/lib/buffer-to-svg.ts
+++ b/src/lib/buffer-to-svg.ts
@@ -159,7 +159,7 @@ export function bufferToSvg(
   }
 
   // Render cursor if visible
-  if (terminal.modes.showCursor) {
+  if ((terminal.modes as { showCursor?: boolean }).showCursor) {
     const cursorX = buffer.cursorX;
     const cursorY = buffer.cursorY;
 

--- a/src/tools/shell-screenshot.ts
+++ b/src/tools/shell-screenshot.ts
@@ -53,8 +53,16 @@ export async function shellScreenshot(
 
   context.log(`[shellwright] Screenshot saved: ${screenshotDir}/${baseName}.{png,svg,ansi,txt}`);
 
-  const downloadUrl = context.getDownloadUrl(context.getMcpSessionId(), session_id, "screenshots", filename);
-  const output = { filename, download_url: downloadUrl, hint: "Use curl -o <filename> <download_url> to save the file" };
+  const mcpSessionId = context.getMcpSessionId();
+  const pngUrl = context.getDownloadUrl(mcpSessionId, session_id, "screenshots", `${baseName}.png`);
+  const svgUrl = context.getDownloadUrl(mcpSessionId, session_id, "screenshots", `${baseName}.svg`);
+  const output = {
+    filename,
+    download_url: pngUrl,
+    png_url: pngUrl,
+    svg_url: svgUrl,
+    hint: "Use curl -o <filename> <download_url> to save the file",
+  };
   context.logToolCall("shell_screenshot", { session_id, name }, output);
 
   return {


### PR DESCRIPTION
## Summary

Adds `png_url` and `svg_url` to the `shell_screenshot` tool response, addressing issue #45.

### Changes

- **shell_screenshot** now returns both URLs in the response:
  ```json
  {
    "filename": "screenshot.png",
    "download_url": "http://localhost:7498/files/.../screenshot.png",
    "png_url": "http://localhost:7498/files/.../screenshot.png",
    "svg_url": "http://localhost:7498/files/.../screenshot.svg",
    "hint": "Use curl -o <filename> <download_url> to save the file"
  }
  ```

- Keeps `download_url` (pointing to PNG) for backward compatibility
- Updated tool description to mention both formats

### Additional fix

- Fixed TypeScript error in `buffer-to-svg.ts`: `showCursor` is not in the `IModes` type definition from @xterm/headless. Added type assertion to unblock local build.

### Testing

- ✅ Build succeeds
- ✅ Tests pass
- ✅ Linting passes

Closes #45