### PR TITLE
chore: openspec-flow setup

### DIFF
--- a/.github/workflows/openspec-flow.yml
+++ b/.github/workflows/openspec-flow.yml
@@ -1,0 +1,19 @@
+# Maintained by openspec-flow. Edit the `uses:` ref to upgrade.
+# Docs: https://github.com/dwmkerr/openspec-flow
+name: openspec-flow
+on:
+  issues:
+    types: [labeled]
+  pull_request:
+    types: [labeled, closed]
+  pull_request_review_comment:
+    types: [created]
+  issue_comment:
+    types: [created]
+jobs:
+  flow:
+    uses: dwmkerr/openspec-flow/.github/workflows/openspec-flow.yml@main
+    secrets:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      OPENSPEC_FLOW_APP_ID: ${{ secrets.OPENSPEC_FLOW_APP_ID || '' }}
+      OPENSPEC_FLOW_PRIVATE_KEY: ${{ secrets.OPENSPEC_FLOW_PRIVATE_KEY || '' }}

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+<!-- openspec-flow badge-start -->
+[![openspec-flow](https://github.com/dwmkerr/shellwright/actions/workflows/openspec-flow.yml/badge.svg)](https://github.com/dwmkerr/shellwright/actions/workflows/openspec-flow.yml)
+<!-- openspec-flow badge-end -->
+
 <p align="center">
   <h2 align="center"><code>🖥️ shellwright</code></h2>
   <h3 align="center">Playwright for the shell. AI-driven terminal automation, screenshots and video recording.</h3>
@@ -467,3 +471,16 @@ This project follows the [all-contributors](https://github.com/all-contributors/
 ## License
 
 MIT
+
+<!-- openspec-flow install-start -->
+## openspec-flow
+
+This repo uses [openspec-flow](https://github.com/dwmkerr/openspec-flow) to drive spec-driven development from GitHub issues.
+
+1. Open an issue describing the feature, fix, or task.
+2. Add the `openspec:go` label.
+3. openspec-flow opens a **spec PR** (`openspec:spec`). Review, comment, iterate (add `openspec:go` to the PR to re-run). Merge when happy.
+4. openspec-flow opens an **impl PR** (`openspec:impl`). Review, iterate, merge. The originating issue closes automatically.
+
+Required Actions secret: `ANTHROPIC_API_KEY`.
+<!-- openspec-flow install-end -->


### PR DESCRIPTION
openspec-flow setup

This PR was opened automatically by the openspec-flow GitHub App on install. Merging it wires this repository into the spec-driven flow.

## What this PR adds

- `.github/workflows/openspec-flow.yml` — the reusable-workflow shim that drives the flow on every `openspec:go` label.
- A badge under the README H1 linking to the workflow's runs.
- A short README block describing the user-facing flow.

## Before merging

Set the required Actions secret on this repository:

```bash
gh secret set ANTHROPIC_API_KEY -R dwmkerr/shellwright
```

Without that secret, the first `openspec:go` run will fail.

## After merging

1. Open an issue describing a feature, fix, or task.
2. Add the `openspec:go` label.
3. openspec-flow opens a spec PR. Review, iterate, merge.
4. openspec-flow opens an impl PR. Review, iterate, merge.

See https://github.com/dwmkerr/openspec-flow for the full docs.