### PR TITLE
fix: add permissions block required by reusable workflow

### DIFF
--- a/.github/workflows/openspec-flow.yml
+++ b/.github/workflows/openspec-flow.yml
@@ -10,6 +10,14 @@ on:
     types: [created]
   issue_comment:
     types: [created]
+# Reusable workflows can only declare permissions UP TO what the caller
+# grants. Without this block the reusable workflow's `contents: write`
+# request is rejected with: "is requesting 'contents: write, issues:
+# write, pull-requests: write', but is only allowed 'contents: read…'".
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
 jobs:
   flow:
     uses: dwmkerr/openspec-flow/.github/workflows/openspec-flow.yml@main

--- a/.github/workflows/openspec-flow.yml
+++ b/.github/workflows/openspec-flow.yml
@@ -1,0 +1,19 @@
+# Maintained by openspec-flow. Edit the `uses:` ref to upgrade.
+# Docs: https://github.com/dwmkerr/openspec-flow
+name: openspec-flow
+on:
+  issues:
+    types: [labeled]
+  pull_request:
+    types: [labeled, closed]
+  pull_request_review_comment:
+    types: [created]
+  issue_comment:
+    types: [created]
+jobs:
+  flow:
+    uses: dwmkerr/openspec-flow/.github/workflows/openspec-flow.yml@main
+    secrets:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      OPENSPEC_FLOW_APP_ID: ${{ secrets.OPENSPEC_FLOW_APP_ID || '' }}
+      OPENSPEC_FLOW_PRIVATE_KEY: ${{ secrets.OPENSPEC_FLOW_PRIVATE_KEY || '' }}

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+<!-- openspec-flow badge-start -->
+[![openspec-flow](https://github.com/dwmkerr/shellwright/actions/workflows/openspec-flow.yml/badge.svg)](https://github.com/dwmkerr/shellwright/actions/workflows/openspec-flow.yml)
+<!-- openspec-flow badge-end -->
+
 <p align="center">
   <h2 align="center"><code>🖥️ shellwright</code></h2>
   <h3 align="center">Playwright for the shell. AI-driven terminal automation, screenshots and video recording.</h3>
@@ -467,3 +471,16 @@ This project follows the [all-contributors](https://github.com/all-contributors/
 ## License
 
 MIT
+
+<!-- openspec-flow install-start -->
+## openspec-flow
+
+This repo uses [openspec-flow](https://github.com/dwmkerr/openspec-flow) to drive spec-driven development from GitHub issues.
+
+1. Open an issue describing the feature, fix, or task.
+2. Add the `openspec:go` label.
+3. openspec-flow opens a **spec PR** (`openspec:spec`). Review, comment, iterate (add `openspec:go` to the PR to re-run). Merge when happy.
+4. openspec-flow opens an **impl PR** (`openspec:impl`). Review, iterate, merge. The originating issue closes automatically.
+
+Required Actions secret: `ANTHROPIC_API_KEY`.
+<!-- openspec-flow install-end -->


### PR DESCRIPTION
Without this block the openspec-flow reusable workflow fails:

```
is requesting 'contents: write, issues: write, pull-requests: write',
but is only allowed 'contents: read, issues: none, pull-requests: none'
```

Reusable workflows can only request permissions the caller grants. The shim template upstream now carries this block; this PR's branch was generated before the fix landed (PR #74 / #75 shipped without it).

Follow-up issue tracks the systematic fleet-upgrade story.