### PR TITLE
feat: add shell_wait_for, submit option, and final-frame hold for TUI recording

### DIFF
--- a/.github/workflows/recording-eval.yaml
+++ b/.github/workflows/recording-eval.yaml
@@ -65,13 +65,24 @@ jobs:
         run: npm run compare
 
       - name: Deploy recordings to GitHub Pages
+        if: github.event.action != 'closed'
         uses: rossjrw/pr-preview-action@v1
         id: preview
         with:
           source-dir: ./evaluations/scenarios/
           preview-branch: gh-pages
           umbrella-dir: pr-preview
-          action: auto
+          action: deploy
+          comment: false
+
+      # Keep previews for merged PRs as an evidence trail; only clean up abandoned PRs
+      - name: Remove preview (closed without merge)
+        if: github.event.action == 'closed' && !github.event.pull_request.merged
+        uses: rossjrw/pr-preview-action@v1
+        with:
+          preview-branch: gh-pages
+          umbrella-dir: pr-preview
+          action: remove
           comment: false
 
       - name: Comment with preview link

--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ Some configuration can also be provided by the LLM, simply prompt for it:
 | [`shell_start`](#shell_start) | Start a new PTY session |
 | [`shell_send`](#shell_send) | Send input to a session |
 | [`shell_read`](#shell_read) | Read the terminal buffer |
+| [`shell_wait_for`](#shell_wait_for) | Wait for the buffer to satisfy conditions |
 | [`shell_screenshot`](#shell_screenshot) | Capture terminal as PNG and SVG |
 | [`shell_record_start`](#shell_record_start) | Start recording for GIF export |
 | [`shell_record_stop`](#shell_record_stop) | Stop recording and save GIF |
@@ -258,6 +259,17 @@ Send input to a PTY session. Returns the full terminal buffer (plain text, no AN
 
 The `delay_ms` parameter controls how long to wait after sending input before capturing `bufferAfter` (default: 100ms). Increase for slow commands.
 
+For chat TUIs (e.g. Claude Code) where a trailing `\r` inside pasted text is treated as part of the paste instead of submitting it, use `submit: true` to send Enter as a separate keystroke after the input has settled (`submit_delay_ms`, default 1000ms):
+
+```json
+{
+  "session_id": "shell-session-a1b2c3",
+  "input": "Which agents run in this cluster?",
+  "submit": true,
+  "submit_delay_ms": 1000
+}
+```
+
 The response includes the terminal buffer before and after the input was sent:
 
 ```json
@@ -286,6 +298,32 @@ total 24
 drwxr-xr-x  5 user staff  160 Dec 18 10:00 .
 drwxr-xr-x 10 user staff  320 Dec 18 09:00 ..
 -rw-r--r--  1 user staff 1234 Dec 18 10:00 README.md
+```
+
+### **shell_wait_for**
+
+Wait until the terminal buffer satisfies conditions, instead of polling `shell_read` in a loop. Completes when all given conditions hold: `pattern` matches, `absent_pattern` does not match, and the buffer has been unchanged for `stable_ms`:
+
+```json
+{
+  "session_id": "shell-session-a1b2c3",
+  "absent_pattern": "esc to interrupt| for \\d+s",
+  "stable_ms": 4000,
+  "timeout_ms": 90000
+}
+```
+
+The example above waits for a Claude Code response to finish: the busy marker is gone and the screen has been still for four seconds. See [Recording Claude Code](./docs/recording-claude-code.md) for the full workflow.
+
+The response reports whether the conditions were met and includes the final buffer:
+
+```json
+{
+  "satisfied": true,
+  "timed_out": false,
+  "waited_ms": 38500,
+  "buffer": "..."
+}
 ```
 
 ### **shell_screenshot**
@@ -335,12 +373,13 @@ The response confirms recording has started:
 
 ### **shell_record_stop**
 
-Stop recording and render frames to GIF:
+Stop recording and render frames to GIF. The final frame is held for `hold_last_ms` (default 2000ms, `0` to disable) so the ending doesn't flash past before the GIF loops:
 
 ```json
 {
   "session_id": "shell-session-a1b2c3",
-  "name": "my-recording"
+  "name": "my-recording",
+  "hold_last_ms": 2000
 }
 ```
 

--- a/docs/examples/drive-claude.mjs
+++ b/docs/examples/drive-claude.mjs
@@ -1,0 +1,140 @@
+// Adaptive driver: records a REAL interactive Claude Code session over the
+// shellwright MCP server. Polls the terminal buffer and infers UI state
+// (trust dialog, busy spinner, idle prompt) instead of fixed sleeps.
+import {Client} from '@modelcontextprotocol/sdk/client/index.js';
+import {StreamableHTTPClientTransport} from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+
+const serverUrl = process.argv[2] || 'http://localhost:7499/mcp';
+const BUNDLE_DIR =
+  '/Users/Dave_Kerr/repos/github/dwmkerr/agents-at-scale-ark/scratch/okf-demo/ark-okf-bundle';
+
+const client = new Client({name: 'okf-claude-driver', version: '0.0.2'});
+await client.connect(new StreamableHTTPClientTransport(new URL(serverUrl)));
+
+let sessionId = null;
+async function call(tool, args = {}) {
+  if (sessionId && !args.session_id) args.session_id = sessionId;
+  const result = await client.callTool({name: tool, arguments: args});
+  const text = result.content?.map((c) => c.text).join('\n') || '';
+  try {
+    const parsed = JSON.parse(text);
+    if (parsed.shell_session_id) sessionId = parsed.shell_session_id;
+    return parsed;
+  } catch {
+    return text;
+  }
+}
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+const read = async () => String(await call('shell_read'));
+const send = (input, delay_ms = 200) => call('shell_send', {input, delay_ms});
+
+// Claude Code shows "esc to interrupt" while working; treat its absence plus
+// a stable buffer as "idle and finished responding".
+async function waitIdle(label, {timeoutMs = 120000, stableFor = 3} = {}) {
+  const start = Date.now();
+  let prev = '';
+  let stable = 0;
+  while (Date.now() - start < timeoutMs) {
+    await sleep(2000);
+    const buf = await read();
+    // Spinner shows a random gerund ("Churned/Cooked/... for NNs") - match the
+    // shape, not the word list.
+    const busy =
+      buf.includes('esc to interrupt') ||
+      buf.includes('esc to cancel') ||
+      buf.includes('ctrl+c to interrupt') ||
+      / for \d+s/.test(buf.slice(-500));
+    if (!busy && buf === prev) {
+      stable += 1;
+      if (stable >= stableFor) {
+        console.log(`[idle] ${label} after ${Math.round((Date.now() - start) / 1000)}s`);
+        return buf;
+      }
+    } else {
+      stable = 0;
+    }
+    prev = buf;
+  }
+  console.log(`[timeout] ${label} - continuing anyway`);
+  return prev;
+}
+
+async function screenshot(name, title) {
+  const r = await call('shell_screenshot', {name, border: {style: 'macos', title}});
+  console.log(`[shot] ${r.filename}`);
+}
+
+// --- scenario ---
+await call('shell_start', {command: 'bash', args: ['--noprofile', '--norc'], cols: 110, rows: 32});
+await send(
+  `unset CLAUDECODE CLAUDE_CODE_ENTRYPOINT CLAUDE_CODE_SSE_PORT; export PS1='$ ' && cd ${BUNDLE_DIR} && clear\r`,
+  500
+);
+await call('shell_record_start', {
+  fps: 10,
+  border: {style: 'macos', title: 'A real Claude Code session over an exported Ark OKF bundle'},
+});
+await sleep(500);
+await send('ls\r', 1000);
+await sleep(1000);
+
+await send('claude --model sonnet\r', 2000);
+
+// Handle the first-run trust dialog if it appears, then wait for the input box.
+let buf = '';
+for (let i = 0; i < 20; i++) {
+  await sleep(1500);
+  buf = await read();
+  if (/trust the files|Do you trust/i.test(buf)) {
+    console.log('[ui] trust dialog - accepting');
+    await send('\r', 500);
+    continue;
+  }
+  if (/\? for shortcuts|>\s*$|Try "/m.test(buf)) break;
+}
+console.log('[ui] claude TUI ready');
+await screenshot('07-claude-start', 'Claude Code (sonnet) starting in the bundle directory');
+
+// Type a question once, submit, confirm the TUI went busy (re-sending only
+// the Enter key if it did not), then wait for the response to finish.
+async function ask(question, label) {
+  await send(question, 1200);
+  await sleep(2000);
+  await send('\r', 500);
+  let busySeen = false;
+  const start = Date.now();
+  while (Date.now() - start < 25000) {
+    await sleep(1500);
+    const buf = await read();
+    if (/esc to interrupt| for \d+s/.test(buf)) {
+      busySeen = true;
+      break;
+    }
+    if (Date.now() - start > 6000) {
+      console.log('[nudge] no busy marker - re-sending Enter');
+      await send('\r', 500);
+    }
+  }
+  console.log(`[busy=${busySeen}] ${label}`);
+  await waitIdle(label, {timeoutMs: 120000});
+  await sleep(3000);
+}
+
+const q1 =
+  'Look at the OKF bundle in this directory. Which agents run in this Ark cluster and which model do they use? Be brief.';
+await ask(q1, 'first answer');
+await screenshot('09-answer-agents', 'Agents and model, read from the OKF bundle');
+
+const q2 =
+  'Which tools does the ark-operator agent have, and which MCP server serves them? Cite the files you used.';
+await ask(q2, 'second answer');
+await screenshot('10-answer-tools', 'Tool + MCP server graph traversed via markdown links');
+
+await sleep(2000);
+await send('/exit', 600);
+await send('\r', 500);
+await sleep(2500);
+const gif = await call('shell_record_stop', {name: 'claude-live-okf'});
+console.log(`[gif] ${gif.filename} frames=${gif.frame_count} duration=${gif.duration_ms}ms`);
+await call('shell_stop');
+await client.close();

--- a/docs/recording-claude-code.md
+++ b/docs/recording-claude-code.md
@@ -1,0 +1,79 @@
+# Recording Claude Code Sessions
+
+Notes from driving a real interactive Claude Code session with Shellwright
+(via a scripted MCP client, no human at the keyboard). What works, what
+bites, and a proven recipe.
+
+## The short version
+
+1. Start a plain shell first, `cd` and set `PS1` *before* `shell_record_start`.
+2. Launch with `claude --model sonnet` inside the recorded shell.
+3. Send question text and the submitting `\r` as **two separate**
+   `shell_send` calls, ~1-2s apart. A trailing `\r` inside one send can be
+   swallowed by bracketed paste.
+4. Detect "Claude is working" with `esc to interrupt` or the spinner shape
+   `/ for \d+s/` in the buffer. Do **not** match spinner verbs — they are
+   random gerunds ("Churned", "Cooked", "Brewed", ...).
+5. Detect "done" as: no busy marker AND buffer unchanged across 2-3 polls
+   (2s apart).
+6. Unset `CLAUDECODE` / `CLAUDE_CODE_ENTRYPOINT` in the shell if the driver
+   itself runs under Claude Code, or the nested TUI may behave differently.
+7. Expect a first-run trust dialog in fresh directories; answer with `\r`.
+
+A working adaptive driver (poll buffer, infer UI state, retry the Enter key
+only — never retype the question) is at
+[`docs/examples/drive-claude.mjs`](examples/drive-claude.mjs). It predates
+`shell_wait_for` and shows the manual polling approach; with the new tool the
+wait loops collapse to single calls.
+
+## Pitfalls found in real use
+
+| Pitfall | Symptom | Fix / recommendation |
+|---|---|---|
+| Port conflict crashed silently | startup banner prints, process dies; POST /mcp answered with Express 404 by the *old* process that owns the port | fixed: `listen` errors are now handled - HTTP mode exits loudly on `EADDRINUSE`, stdio mode warns |
+| `node-pty` built for old Node | `Cannot find module ../build/Debug/pty.node` | `npm rebuild node-pty`; startup could catch this and print the fix |
+| Retyping unverified input | question appears 2-3x in the TUI input box | verify by *submitting* again (`\r`), never resend the text; or use `shell_send` with `submit: true` |
+| Long silent turns → sparse GIF frames | 75s of thinking = 1-2 frames, answer flashes at the end | fixed: `shell_record_stop` now holds the final frame (`hold_last_ms`, default 2s) |
+
+## Tooling added for this workflow
+
+- **`shell_wait_for`** — `{pattern, absent_pattern, stable_ms, timeout_ms}`.
+  Replaces client-side `shell_read` polling loops when driving any TUI
+  (Claude Code, vim, k9s).
+- **`shell_send` `submit: true`** — paste text, settle delay
+  (`submit_delay_ms`, default 1s), then Enter as a separate keystroke. The
+  paste-then-submit pattern every chat TUI needs.
+- **`shell_record_stop` `hold_last_ms`** — holds the final frame (default
+  2000ms) so the ending doesn't flash past before the GIF loops.
+
+## Remaining ideas
+
+- **`speed` option on record stop** — a 5-minute Claude turn should compress
+  to a ~20s GIF; wall-clock playback of thinking time is dead air.
+- **Startup hint for broken `node-pty`** — catch the native-module load error
+  and print `npm rebuild node-pty`.
+
+## Reference driver
+
+[`docs/examples/drive-claude.mjs`](examples/drive-claude.mjs) is the adaptive
+driver used to record a real session (two questions, file citations in the
+answers) against an [Ark](https://github.com/mckinsey/agents-at-scale-ark)
+OKF bundle. Core loop:
+
+```js
+// busy: Claude Code shows "esc to interrupt" while streaming, and a
+// "<Gerund> for NNs" spinner while thinking - match the shape, not the verb.
+const busy =
+  buf.includes('esc to interrupt') || / for \d+s/.test(buf.slice(-500));
+
+// idle: no busy marker AND buffer stable across 3 polls, 2s apart
+```
+
+Submit questions like this:
+
+```js
+await send(question, 1200);   // paste text into the input box
+await sleep(2000);            // let the TUI render it
+await send('\r', 500);        // submit as a separate keystroke
+// if no busy marker within ~6s, re-send '\r' only (never the text)
+```

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,8 @@ import {
   shellRecordStartSchema,
   shellRecordStop,
   shellRecordStopSchema,
+  shellWaitFor,
+  shellWaitForSchema,
   Session,
   ToolContext,
 } from "./tools/index.js";
@@ -208,6 +210,18 @@ Tips:
   );
 
   server.tool(
+    "shell_wait_for",
+    `Wait until the terminal buffer satisfies conditions, instead of polling shell_read in a loop. Completes when ALL given conditions hold: 'pattern' matches, 'absent_pattern' does not match, and the buffer has been unchanged for 'stable_ms'.
+
+Tips:
+- Wait for a shell prompt: pattern: "\\\\$ $"
+- Wait for a chat TUI (e.g. Claude Code) to finish responding: absent_pattern: "esc to interrupt| for \\\\d+s", stable_ms: 4000
+- Returns { satisfied, timed_out, waited_ms, buffer } - always check 'satisfied'`,
+    shellWaitForSchema,
+    async (params) => shellWaitFor(params, toolContext)
+  );
+
+  server.tool(
     "shell_stop",
     "Stop a PTY session",
     shellStopSchema,
@@ -318,9 +332,22 @@ if (USE_HTTP) {
     await transport.handleRequest(req, res);
   });
 
-  app.listen(PORT, () => {
+  const httpServer = app.listen(PORT, () => {
     log(`[shellwright] MCP server running at http://localhost:${PORT}/mcp`);
     log(`[shellwright] File server running at http://localhost:${PORT}/files`);
+  });
+
+  // Without this, a port conflict is an unhandled 'error' event: the startup
+  // banner prints, then the process dies - and if another shellwright (e.g. a
+  // stdio-mode file server) owns the port, clients get its 404s and blame the
+  // new instance. Fail loudly instead.
+  httpServer.on("error", (err: NodeJS.ErrnoException) => {
+    if (err.code === "EADDRINUSE") {
+      console.error(`[shellwright] Port ${PORT} is already in use (another shellwright instance?). Choose a different port with --port.`);
+    } else {
+      console.error(`[shellwright] Failed to start HTTP server: ${err.message}`);
+    }
+    process.exit(1);
   });
 
   process.on("SIGINT", async () => {
@@ -338,8 +365,18 @@ if (USE_HTTP) {
 
   // Start HTTP file server (needed for download URLs)
   const fileServer = createFileServer();
-  fileServer.listen(PORT, () => {
+  const fileServerInstance = fileServer.listen(PORT, () => {
     log(`[shellwright] File server running at http://localhost:${PORT}/files`);
+  });
+
+  // MCP over stdio still works without the file server; warn rather than die,
+  // but say clearly that download URLs will point at whoever owns the port.
+  fileServerInstance.on("error", (err: NodeJS.ErrnoException) => {
+    if (err.code === "EADDRINUSE") {
+      log(`[shellwright] WARNING: port ${PORT} in use - download URLs will not be served by this instance. Use --port to change.`);
+    } else {
+      log(`[shellwright] WARNING: file server failed to start: ${err.message}`);
+    }
   });
 
   log(`[shellwright] Session: ${stdioSessionId}`);

--- a/src/lib/render-gif.ts
+++ b/src/lib/render-gif.ts
@@ -11,6 +11,7 @@ import * as crypto from "crypto";
 export interface RenderGifOptions {
   fps?: number;
   loop?: number; // 0 = infinite
+  holdLastMs?: number; // extra display time for the final frame
 }
 
 export interface RenderGifResult {
@@ -95,11 +96,14 @@ export async function renderGif(
   }
 
   if (pendingFrame) {
+    // Hold the final frame so viewers see the end state before the loop
+    // restarts - without this the closing moment flashes past.
+    const finalDelay = pendingFrame.accumulatedDelay + (options.holdLastMs || 0);
     gif.writeFrame(pendingFrame.indexed, width, height, {
       palette: pendingFrame.palette,
-      delay: pendingFrame.accumulatedDelay,
+      delay: finalDelay,
     });
-    totalDurationMs += pendingFrame.accumulatedDelay;
+    totalDurationMs += finalDelay;
     framesWritten++;
   }
 

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -5,4 +5,5 @@ export { shellScreenshot, shellScreenshotSchema } from "./shell-screenshot.js";
 export { shellStop, shellStopSchema } from "./shell-stop.js";
 export { shellRecordStart, shellRecordStartSchema } from "./shell-record-start.js";
 export { shellRecordStop, shellRecordStopSchema } from "./shell-record-stop.js";
+export { shellWaitFor, shellWaitForSchema } from "./shell-wait-for.js";
 export type { Session, RecordingState, ToolContext } from "./types.js";

--- a/src/tools/shell-record-stop.ts
+++ b/src/tools/shell-record-stop.ts
@@ -7,13 +7,16 @@ import { ToolContext } from "./types.js";
 export const shellRecordStopSchema = {
   session_id: z.string().describe("Session ID"),
   name: z.string().optional().describe("Recording name (default: recording_{timestamp})"),
+  hold_last_ms: z.number().optional().describe(
+    "Extra display time for the final frame (default: 2000, 0 to disable). Prevents the ending - usually the payoff - from flashing past before the GIF loops."
+  ),
 };
 
 export async function shellRecordStop(
-  params: { session_id: string; name?: string },
+  params: { session_id: string; name?: string; hold_last_ms?: number },
   context: ToolContext
 ) {
-  const { session_id, name } = params;
+  const { session_id, name, hold_last_ms } = params;
   const session = context.sessions.get(session_id);
   if (!session) {
     throw new Error(`Session not found: ${session_id}`);
@@ -35,7 +38,7 @@ export async function shellRecordStop(
 
   await fs.mkdir(recordingsDir, { recursive: true });
 
-  const result = await renderGif(framesDir, filePath, { fps });
+  const result = await renderGif(framesDir, filePath, { fps, holdLastMs: hold_last_ms ?? 2000 });
 
   // Cleanup frames (keep the GIF for diagnostics)
   await fs.rm(framesDir, { recursive: true, force: true });
@@ -52,7 +55,7 @@ export async function shellRecordStop(
     duration_ms: durationMs,
     hint: "Use curl -o <filename> <url> to save the file"
   };
-  context.logToolCall("shell_record_stop", { session_id, name }, output);
+  context.logToolCall("shell_record_stop", { session_id, name, hold_last_ms }, output);
 
   return {
     content: [{ type: "text" as const, text: JSON.stringify(output) }],

--- a/src/tools/shell-send.ts
+++ b/src/tools/shell-send.ts
@@ -17,13 +17,25 @@ export const shellSendSchema = {
   session_id: z.string().describe("Session ID"),
   input: z.string().describe("Input to send (supports escape sequences like \\x1b[A for arrow up)"),
   delay_ms: z.number().optional().describe("Milliseconds to wait after sending input before capturing 'bufferAfter' (default: 100). Increase for slow commands."),
+  submit: z.boolean().optional().describe(
+    "Send Enter as a SEPARATE keystroke after the input has settled (default: false). Use for chat TUIs (e.g. Claude Code) where a trailing \\r inside pasted text is treated as part of the paste instead of submitting it."
+  ),
+  submit_delay_ms: z.number().optional().describe(
+    "How long to let the TUI render the pasted input before the submit keystroke (default: 1000; only used with submit: true)"
+  ),
 };
 
 export async function shellSend(
-  params: { session_id: string; input: string; delay_ms?: number },
+  params: {
+    session_id: string;
+    input: string;
+    delay_ms?: number;
+    submit?: boolean;
+    submit_delay_ms?: number;
+  },
   context: ToolContext
 ) {
-  const { session_id, input, delay_ms } = params;
+  const { session_id, input, delay_ms, submit, submit_delay_ms } = params;
   const session = context.sessions.get(session_id);
   if (!session) {
     throw new Error(`Session not found: ${session_id}`);
@@ -35,12 +47,18 @@ export async function shellSend(
   session.pty.write(interpreted);
   context.log(`[shellwright] Sent to ${session_id}: ${JSON.stringify(input)}`);
 
+  if (submit) {
+    await new Promise((resolve) => setTimeout(resolve, submit_delay_ms ?? 1000));
+    session.pty.write("\r");
+    context.log(`[shellwright] Submitted (Enter) to ${session_id}`);
+  }
+
   await new Promise((resolve) => setTimeout(resolve, delay_ms || 100));
 
   const bufferAfter = bufferToText(session.terminal, session.cols, session.rows);
 
   const output = { success: true, bufferBefore, bufferAfter };
-  context.logToolCall("shell_send", { session_id, input, delay_ms }, output);
+  context.logToolCall("shell_send", { session_id, input, delay_ms, submit, submit_delay_ms }, output);
 
   return {
     content: [{ type: "text" as const, text: JSON.stringify(output) }],

--- a/src/tools/shell-wait-for.test.ts
+++ b/src/tools/shell-wait-for.test.ts
@@ -1,0 +1,34 @@
+import { bufferSatisfies } from "./shell-wait-for.js";
+
+describe("bufferSatisfies", () => {
+  it("passes when no conditions are given", () => {
+    expect(bufferSatisfies("anything", {})).toBe(true);
+  });
+
+  it("requires pattern to match", () => {
+    expect(bufferSatisfies("bash-5.2$ ", { pattern: "\\$ $" })).toBe(true);
+    expect(bufferSatisfies("still running...", { pattern: "\\$ $" })).toBe(false);
+  });
+
+  it("requires absent pattern to be absent", () => {
+    const busy = "✳ Churned for 12s · esc to interrupt";
+    const idle = "response text\n> ";
+    const absentPattern = "esc to interrupt| for \\d+s";
+    expect(bufferSatisfies(busy, { absentPattern })).toBe(false);
+    expect(bufferSatisfies(idle, { absentPattern })).toBe(true);
+  });
+
+  it("matches spinner shape regardless of the gerund", () => {
+    const absentPattern = " for \\d+s";
+    for (const verb of ["Churned", "Cooked", "Brewed", "Percolated"]) {
+      expect(bufferSatisfies(`✳ ${verb} for 34s`, { absentPattern })).toBe(false);
+    }
+  });
+
+  it("combines pattern and absent pattern", () => {
+    const conditions = { pattern: "> $", absentPattern: "esc to interrupt" };
+    expect(bufferSatisfies("done\n> ", conditions)).toBe(true);
+    expect(bufferSatisfies("done, esc to interrupt\n> ", conditions)).toBe(false);
+    expect(bufferSatisfies("no prompt here", conditions)).toBe(false);
+  });
+});

--- a/src/tools/shell-wait-for.ts
+++ b/src/tools/shell-wait-for.ts
@@ -1,0 +1,108 @@
+import { z } from "zod";
+import { bufferToText } from "../lib/buffer-to-ansi.js";
+import { ToolContext } from "./types.js";
+
+export const shellWaitForSchema = {
+  session_id: z.string().describe("Session ID"),
+  pattern: z.string().optional().describe(
+    "Regex the buffer must match before the wait completes (e.g. '\\\\$ $' for a shell prompt)"
+  ),
+  absent_pattern: z.string().optional().describe(
+    "Regex the buffer must NOT match before the wait completes (e.g. 'esc to interrupt' while a TUI is busy)"
+  ),
+  stable_ms: z.number().optional().describe(
+    "Buffer must additionally be unchanged for this long (default: 0 = no stability check). Use ~4000 for chat TUIs that stream output."
+  ),
+  timeout_ms: z.number().optional().describe("Give up after this long (default: 30000)"),
+  poll_ms: z.number().optional().describe("Poll interval (default: 250)"),
+};
+
+export interface WaitForConditions {
+  pattern?: string;
+  absentPattern?: string;
+}
+
+// Exported for unit testing - a buffer satisfies the wait when the required
+// pattern matches and the forbidden pattern does not.
+export function bufferSatisfies(buffer: string, conditions: WaitForConditions): boolean {
+  if (conditions.pattern && !new RegExp(conditions.pattern, "m").test(buffer)) {
+    return false;
+  }
+  if (conditions.absentPattern && new RegExp(conditions.absentPattern, "m").test(buffer)) {
+    return false;
+  }
+  return true;
+}
+
+export async function shellWaitFor(
+  params: {
+    session_id: string;
+    pattern?: string;
+    absent_pattern?: string;
+    stable_ms?: number;
+    timeout_ms?: number;
+    poll_ms?: number;
+  },
+  context: ToolContext
+) {
+  const { session_id, pattern, absent_pattern } = params;
+  const stableMs = params.stable_ms ?? 0;
+  const timeoutMs = params.timeout_ms ?? 30000;
+  const pollMs = params.poll_ms ?? 250;
+
+  const session = context.sessions.get(session_id);
+  if (!session) {
+    throw new Error(`Session not found: ${session_id}`);
+  }
+  if (!pattern && !absent_pattern && !stableMs) {
+    throw new Error("Provide at least one of: pattern, absent_pattern, stable_ms");
+  }
+
+  const start = Date.now();
+  let previousBuffer: string | null = null;
+  let stableSince: number | null = null;
+  let buffer = "";
+  let satisfied = false;
+
+  while (Date.now() - start < timeoutMs) {
+    buffer = bufferToText(session.terminal, session.cols, session.rows);
+
+    const conditionsMet = bufferSatisfies(buffer, { pattern, absentPattern: absent_pattern });
+
+    if (buffer === previousBuffer) {
+      stableSince = stableSince ?? Date.now();
+    } else {
+      stableSince = null;
+    }
+    previousBuffer = buffer;
+
+    const stableMet = stableMs === 0 || (stableSince !== null && Date.now() - stableSince >= stableMs);
+
+    if (conditionsMet && stableMet) {
+      satisfied = true;
+      break;
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, pollMs));
+  }
+
+  const waitedMs = Date.now() - start;
+  const output = {
+    satisfied,
+    timed_out: !satisfied,
+    waited_ms: waitedMs,
+    buffer,
+  };
+  context.logToolCall(
+    "shell_wait_for",
+    { session_id, pattern, absent_pattern, stable_ms: stableMs, timeout_ms: timeoutMs },
+    { satisfied, timed_out: !satisfied, waited_ms: waitedMs }
+  );
+  context.log(
+    `[shellwright] wait_for ${session_id}: ${satisfied ? "satisfied" : "timed out"} after ${waitedMs}ms`
+  );
+
+  return {
+    content: [{ type: "text" as const, text: JSON.stringify(output) }],
+  };
+}


### PR DESCRIPTION
## Summary
- `shell_wait_for` tool: wait server-side until the terminal buffer matches `pattern`, does not match `absent_pattern`, and has been stable for `stable_ms` - replaces client-side `shell_read` polling loops when driving TUIs (Claude Code, vim, k9s)
- `shell_send` `submit` option: paste text, settle (`submit_delay_ms`, default 1s), then Enter as a separate keystroke - a trailing `\r` inside pasted text can be swallowed by bracketed paste in chat TUIs
- `shell_record_stop` `hold_last_ms` (default 2s): hold the final GIF frame so the ending doesn't flash past before the loop restarts
- Handle HTTP `listen` errors: `EADDRINUSE` previously crashed the process silently after the startup banner, while a stale instance owning the port served confusing 404s; HTTP mode now exits loudly, stdio mode warns
- New doc: [`docs/recording-claude-code.md`](https://github.com/dwmkerr/shellwright/blob/feat/claude-tui-recording/docs/recording-claude-code.md) - proven recipe for recording real interactive Claude Code sessions, pitfalls table, and a reference adaptive driver ([`docs/examples/drive-claude.mjs`](https://github.com/dwmkerr/shellwright/blob/feat/claude-tui-recording/docs/examples/drive-claude.mjs))

## Evidence

Everything here came out of recording a **real interactive Claude Code session** with Shellwright (scripted MCP driver, no human at keyboard) for the [Ark OKF spike](https://github.com/dwmkerr/agents-at-scale-ark/pull/186).

The session this workflow produced (question typed, submitted, spinner inferred, answer waited for, screenshot, follow-up question, exit - all driven through Shellwright tools):

![claude live session](https://raw.githubusercontent.com/dwmkerr/scratch/master/pull-request-attachments/mckinsey_agents-at-scale-ark/okf-spike/claude-live-okf.gif)

Answer screenshots captured with `shell_screenshot` mid-session - note the second answer cites `agents/ark-operator.md:15-18`:

![answer 1](https://raw.githubusercontent.com/dwmkerr/scratch/master/pull-request-attachments/mckinsey_agents-at-scale-ark/okf-spike/09-answer-agents.png)

![answer 2](https://raw.githubusercontent.com/dwmkerr/scratch/master/pull-request-attachments/mckinsey_agents-at-scale-ark/okf-spike/10-answer-tools.png)

The pitfalls in the doc are all real failures from iterating on this: question text tripled by retype-retries, spinner verbs that can't be enumerated (Churned/Cooked/Brewed...), silent `EADDRINUSE` crash, GIF ending flashing past (the reviewer literally asked "i don't see claude reading tho").

## Verification

```
Test Suites: 2 passed, 2 total
Tests:       6 passed, 6 total
```

Live smoke test against the built server:

```
tools: shell_start,shell_send,shell_read,shell_screenshot,shell_wait_for,shell_stop,shell_record_start,shell_record_stop
wait_for satisfied: true in 2010 ms        # 2s condition, no premature match
timeout case: satisfied= false timed_out= true in 2011 ms
submit ran: true
```

Port conflict now fails loudly:

```
[shellwright] Port 7497 is already in use (another shellwright instance?). Choose a different port with --port.
```

Lint clean. README tool docs updated per CLAUDE.md rule.

