### PR TITLE
fix: reads go stale under high-throughput output (drain before serialize)

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ The response includes the terminal buffer before and after the input was sent:
 
 ### **shell_read**
 
-Read the current terminal buffer. Use `raw: true` to include ANSI escape codes:
+Read the terminal contents (scrollback and screen) as plain text. Use `raw: true` for the raw output stream with ANSI escape codes:
 
 ```json
 {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "start": "node dist/index.js",
     "dev": "tsx watch src/index.ts",
     "dev:http": "tsx watch src/index.ts --http --log-path log.jsonl",
-    "test": "jest",
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest",
     "test:emulator": "tsx tests/run-tests.ts",
     "test:k9s": "tsx tests/04-k9s/run.ts",
     "lint": "eslint src/**/*.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -195,7 +195,7 @@ Tips:
 
   server.tool(
     "shell_read",
-    "Read the current terminal buffer as plain text (no ANSI codes)",
+    "Read the terminal contents (scrollback and screen) as plain text (no ANSI codes). Use raw: true for the raw output stream with ANSI codes.",
     shellReadSchema,
     async (params) => shellRead(params, toolContext)
   );

--- a/src/lib/buffer-to-ansi.test.ts
+++ b/src/lib/buffer-to-ansi.test.ts
@@ -1,0 +1,52 @@
+import xterm from "@xterm/headless";
+const { Terminal } = xterm;
+import { bufferToText, bufferToFullText, drainTerminal } from "./buffer-to-ansi.js";
+
+describe("drainTerminal", () => {
+  it("makes a queued write visible to bufferToText", async () => {
+    const terminal = new Terminal({ cols: 80, rows: 24, allowProposedApi: true });
+    try {
+      terminal.write("hello drain barrier");
+      await drainTerminal(terminal);
+      expect(bufferToText(terminal, 80, 24)).toContain("hello drain barrier");
+    } finally {
+      terminal.dispose();
+    }
+  });
+
+  it("acts as a barrier: all writes queued before the drain are parsed", async () => {
+    const terminal = new Terminal({ cols: 80, rows: 24, allowProposedApi: true });
+    try {
+      for (let i = 0; i < 100; i++) {
+        terminal.write(`line-${i}\r\n`);
+      }
+      terminal.write("FINAL_MARKER");
+      await drainTerminal(terminal);
+
+      const text = bufferToFullText(terminal);
+      expect(text).toContain("line-0");
+      expect(text).toContain("line-99");
+      expect(text).toContain("FINAL_MARKER");
+    } finally {
+      terminal.dispose();
+    }
+  });
+});
+
+describe("bufferToFullText", () => {
+  it("includes scrollback lines that have left the viewport", async () => {
+    const terminal = new Terminal({ cols: 80, rows: 5, allowProposedApi: true });
+    try {
+      for (let i = 0; i < 20; i++) {
+        terminal.write(`scroll-${i}\r\n`);
+      }
+      await drainTerminal(terminal);
+
+      const text = bufferToFullText(terminal);
+      expect(text).toContain("scroll-0");
+      expect(text).toContain("scroll-19");
+    } finally {
+      terminal.dispose();
+    }
+  });
+});

--- a/src/lib/buffer-to-ansi.ts
+++ b/src/lib/buffer-to-ansi.ts
@@ -209,6 +209,26 @@ export function bufferToAnsi(
   return lines.join("\n");
 }
 
+// xterm's write() is asynchronous; the callback of a write fires only after all
+// previously queued data has been parsed, so an empty write is a drain barrier.
+export function drainTerminal(terminal: InstanceType<typeof Terminal>): Promise<void> {
+  return new Promise((resolve) => terminal.write("", () => resolve()));
+}
+
+// Serializes the entire parsed buffer (scrollback + viewport) so shell_read shares
+// a single source of truth with the screenshot/send capture paths.
+export function bufferToFullText(terminal: InstanceType<typeof Terminal>): string {
+  const buffer = terminal.buffer.active;
+  const lines: string[] = [];
+
+  for (let y = 0; y < buffer.length; y++) {
+    const line = buffer.getLine(y);
+    lines.push(line ? line.translateToString(true).trimEnd() : "");
+  }
+
+  return lines.join("\n").trimEnd();
+}
+
 export function bufferToText(
   terminal: InstanceType<typeof Terminal>,
   cols: number,

--- a/src/tools/high-throughput-read.test.ts
+++ b/src/tools/high-throughput-read.test.ts
@@ -1,0 +1,81 @@
+import { randomUUID } from "crypto";
+import { shellStart } from "./shell-start.js";
+import { shellRead } from "./shell-read.js";
+import { bufferToText, drainTerminal } from "../lib/buffer-to-ansi.js";
+import { bufferToSvg } from "../lib/buffer-to-svg.js";
+import { ToolContext, Session } from "./types.js";
+
+function createToolContext(): ToolContext {
+  return {
+    sessions: new Map(),
+    getMcpSessionId: () => undefined,
+    getSessionDir: () => "/tmp/shellwright-test",
+    getDownloadUrl: () => "",
+    log: () => {},
+    logToolCall: () => {},
+    config: {
+      PORT: 0,
+      FONT_SIZE: 14,
+      FONT_FAMILY: "monospace",
+      COLS: 80,
+      ROWS: 24,
+    },
+    resvgOptions: {},
+  };
+}
+
+function firstText(result: { content: { type: "text"; text: string }[] }): string {
+  return result.content[0].text;
+}
+
+describe("reads stay live after a high-throughput output burst", () => {
+  const context = createToolContext();
+  let session: Session;
+
+  afterAll(() => {
+    if (session) {
+      session.pty.kill();
+      session.terminal.dispose();
+    }
+  });
+
+  it("sees a sentinel printed after a \\r flood in every capture path", async () => {
+    const startResult = await shellStart({ command: "bash", cols: 80, rows: 24 }, context);
+    const { shell_session_id } = JSON.parse(firstText(startResult));
+    session = context.sessions.get(shell_session_id)!;
+    expect(session).toBeDefined();
+
+    const rand = randomUUID().replace(/-/g, "").slice(0, 8);
+    const sentinel = `SENTINEL_${rand}`;
+    // The '' split stops the local echo of the typed command from containing the
+    // sentinel, so only real command output can match the assertions below.
+    session.pty.write(
+      `for i in $(seq 1 20000); do printf '\\rline %d' "$i"; done; echo; echo SENTINEL_''${rand}\r`
+    );
+
+    // Wait for the shell to finish the flood and print the sentinel
+    const deadline = Date.now() + 20000;
+    while (Date.now() < deadline && !session.buffer.join("").includes(sentinel)) {
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    }
+    expect(session.buffer.join("")).toContain(sentinel);
+
+    // shell_read serializes the parsed terminal after draining the write queue
+    const readResult = await shellRead({ session_id: shell_session_id }, context);
+    expect(firstText(readResult)).toContain(sentinel);
+
+    // The screenshot/send capture path: bufferToText after an explicit drain
+    await drainTerminal(session.terminal);
+    expect(bufferToText(session.terminal, session.cols, session.rows)).toContain(sentinel);
+
+    // The recording frame path: bufferToSvg after the same drain. The SVG puts
+    // each cell in its own <text> element on its own line, so strip markup and
+    // whitespace before matching (the sentinel contains neither).
+    const svg = bufferToSvg(session.terminal, session.cols, session.rows, {
+      theme: session.theme,
+      fontSize: 14,
+      fontFamily: "monospace",
+    });
+    expect(svg.replace(/<[^>]*>/g, "").replace(/\s+/g, "")).toContain(sentinel);
+  }, 30000);
+});

--- a/src/tools/shell-read.ts
+++ b/src/tools/shell-read.ts
@@ -1,26 +1,10 @@
 import { z } from "zod";
+import { bufferToFullText, drainTerminal } from "../lib/buffer-to-ansi.js";
 import { ToolContext } from "./types.js";
-
-// Basic ANSI stripping (incomplete - see 04-findings.md for why this is insufficient)
-function stripAnsi(str: string): string {
-  return str
-    // eslint-disable-next-line no-control-regex
-    .replace(/\x1b\[[0-9;?]*[a-zA-Z]/g, "")  // CSI sequences
-    // eslint-disable-next-line no-control-regex
-    .replace(/\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)/g, "")  // OSC sequences
-    // eslint-disable-next-line no-control-regex
-    .replace(/\x1b[PX^_][^\x1b]*\x1b\\/g, "")  // DCS/SOS/PM/APC
-    // eslint-disable-next-line no-control-regex, no-useless-escape
-    .replace(/\x1b[\(\)][AB0-2]/g, "")  // Character set selection
-    // eslint-disable-next-line no-control-regex
-    .replace(/\x1b[=>NOM78]/g, "")  // Other escape sequences
-    // eslint-disable-next-line no-control-regex
-    .replace(/[\x00-\x08\x0b\x0c\x0e-\x1f]/g, "");  // Control chars
-}
 
 export const shellReadSchema = {
   session_id: z.string().describe("Session ID"),
-  raw: z.boolean().optional().describe("Return raw ANSI codes (default: false)"),
+  raw: z.boolean().optional().describe("Return the raw output stream with ANSI codes instead of the parsed terminal contents (default: false)"),
 };
 
 export async function shellRead(
@@ -33,9 +17,14 @@ export async function shellRead(
     throw new Error(`Session not found: ${session_id}`);
   }
 
-  let content = session.buffer.join("");
-  if (!raw) {
-    content = stripAnsi(content);
+  let content: string;
+  if (raw) {
+    content = session.buffer.join("");
+  } else {
+    // Serialize the parsed terminal model (same source as shell_screenshot) so the
+    // two tools can never disagree; the raw chunk ring stays behind raw: true.
+    await drainTerminal(session.terminal);
+    content = bufferToFullText(session.terminal);
   }
 
   // Limit to last 8KB to avoid context overflow

--- a/src/tools/shell-record-start.ts
+++ b/src/tools/shell-record-start.ts
@@ -3,6 +3,7 @@ import * as fs from "fs/promises";
 import * as path from "path";
 import { Resvg } from "@resvg/resvg-js";
 import { bufferToSvg } from "../lib/buffer-to-svg.js";
+import { drainTerminal } from "../lib/buffer-to-ansi.js";
 import { ToolContext } from "./types.js";
 
 export const shellRecordStartSchema = {
@@ -33,6 +34,10 @@ export async function shellRecordStart(
   const framesDir = path.join(sessionDir, "frames");
   await fs.mkdir(framesDir, { recursive: true });
 
+  // Re-entrancy guard: the frame capture awaits the terminal drain, so a tick can
+  // still be in flight when the next fires — skip that tick rather than queueing
+  let frameInFlight = false;
+
   session.recording = {
     startTime: Date.now(),
     framesDir,
@@ -40,18 +45,27 @@ export async function shellRecordStart(
     fps: recordingFps,
     border,
     interval: setInterval(async () => {
-      if (!session.recording) return;
+      const recording = session.recording;
+      if (!recording || frameInFlight) return;
 
-      const frameNum = session.recording.frameCount++;
-      const svg = bufferToSvg(session.terminal, session.cols, session.rows, {
-        theme: session.theme,
-        fontSize: context.config.FONT_SIZE,
-        fontFamily: context.config.FONT_FAMILY,
-        border,
-      });
-      const png = new Resvg(svg, context.resvgOptions).render().asPng();
-      const framePath = path.join(framesDir, `frame${String(frameNum).padStart(6, "0")}.png`);
-      await fs.writeFile(framePath, png);
+      frameInFlight = true;
+      try {
+        const frameNum = recording.frameCount++;
+        // Capture only after xterm has parsed all pending output, so frames
+        // reflect the live screen even during high-throughput bursts
+        await drainTerminal(session.terminal);
+        const svg = bufferToSvg(session.terminal, session.cols, session.rows, {
+          theme: session.theme,
+          fontSize: context.config.FONT_SIZE,
+          fontFamily: context.config.FONT_FAMILY,
+          border,
+        });
+        const png = new Resvg(svg, context.resvgOptions).render().asPng();
+        const framePath = path.join(framesDir, `frame${String(frameNum).padStart(6, "0")}.png`);
+        await fs.writeFile(framePath, png);
+      } finally {
+        frameInFlight = false;
+      }
     }, 1000 / recordingFps),
   };
 

--- a/src/tools/shell-screenshot.ts
+++ b/src/tools/shell-screenshot.ts
@@ -3,7 +3,7 @@ import * as fs from "fs/promises";
 import * as path from "path";
 import { Resvg } from "@resvg/resvg-js";
 import { bufferToSvg } from "../lib/buffer-to-svg.js";
-import { bufferToAnsi, bufferToText } from "../lib/buffer-to-ansi.js";
+import { bufferToAnsi, bufferToText, drainTerminal } from "../lib/buffer-to-ansi.js";
 import { ToolContext } from "./types.js";
 
 export const shellScreenshotSchema = {
@@ -32,7 +32,8 @@ export async function shellScreenshot(
 
   await fs.mkdir(screenshotDir, { recursive: true });
 
-  // Generate all formats from xterm buffer
+  // Generate all formats from xterm buffer, after it has parsed all pending output
+  await drainTerminal(session.terminal);
   const svg = bufferToSvg(session.terminal, session.cols, session.rows, {
     theme: session.theme,
     fontSize: context.config.FONT_SIZE,

--- a/src/tools/shell-send.ts
+++ b/src/tools/shell-send.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { bufferToText } from "../lib/buffer-to-ansi.js";
+import { bufferToText, drainTerminal } from "../lib/buffer-to-ansi.js";
 import { ToolContext } from "./types.js";
 
 // Interpret escape sequences in input strings (e.g., \r → carriage return)
@@ -29,6 +29,8 @@ export async function shellSend(
     throw new Error(`Session not found: ${session_id}`);
   }
 
+  // Drain xterm's async parse queue before each capture so both reflect the live screen
+  await drainTerminal(session.terminal);
   const bufferBefore = bufferToText(session.terminal, session.cols, session.rows);
 
   const interpreted = interpretEscapes(input);
@@ -37,6 +39,7 @@ export async function shellSend(
 
   await new Promise((resolve) => setTimeout(resolve, delay_ms || 100));
 
+  await drainTerminal(session.terminal);
   const bufferAfter = bufferToText(session.terminal, session.cols, session.rows);
 
   const output = { success: true, bufferBefore, bufferAfter };


### PR DESCRIPTION
## Summary
- Drain xterm's async write queue before every serialize (read/screenshot/send/recording frames) so reads always reflect the live screen — fixes stale-frame wedge under output floods. Fixes #82
- shell_read (non-raw) now serializes the parsed terminal buffer (scrollback+viewport) instead of the raw chunk ring, so it can no longer disagree with shell_screenshot or return animation-frame noise; raw:true unchanged
- Adds the repo's first real jest tests: a drain-barrier unit test and a real-PTY flood→sentinel integration test (new pattern — flagging for maintainer review)