### PR TITLE
ci: support Claude credentials for evals via repository secrets

### DIFF
--- a/.github/workflows/recording-eval.yaml
+++ b/.github/workflows/recording-eval.yaml
@@ -16,48 +16,65 @@ jobs:
       contents: write
       pull-requests: write
     env:
-      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      # Subscription auth via a `claude setup-token` OAuth token. The Claude CLI
+      # prefers ANTHROPIC_API_KEY over CLAUDE_CODE_OAUTH_TOKEN, so only expose
+      # the API key when no OAuth token is configured.
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+      ANTHROPIC_API_KEY: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN == '' && secrets.ANTHROPIC_API_KEY || '' }}
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install system dependencies
+      # Skip evaluations gracefully when no Claude credentials are available
+      # (e.g. fork PRs, where secrets are not exposed) rather than failing.
+      - name: Check Claude credentials
+        id: credentials
         if: github.event.action != 'closed'
+        run: |
+          if [ -n "$CLAUDE_CODE_OAUTH_TOKEN" ] || [ -n "$ANTHROPIC_API_KEY" ]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Skipping evaluations: no CLAUDE_CODE_OAUTH_TOKEN or ANTHROPIC_API_KEY secret available."
+          fi
+
+      - name: Install system dependencies
+        if: github.event.action != 'closed' && steps.credentials.outputs.available == 'true'
         run: |
           sudo apt-get update
           sudo apt-get install -y fonts-hack-ttf neovim
           fc-cache -fv
 
       - name: Setup Node.js
-        if: github.event.action != 'closed'
+        if: github.event.action != 'closed' && steps.credentials.outputs.available == 'true'
         uses: actions/setup-node@v4
         with:
           node-version: "20"
           cache: "npm"
 
       - name: Install Claude CLI
-        if: github.event.action != 'closed'
+        if: github.event.action != 'closed' && steps.credentials.outputs.available == 'true'
         run: npm install -g @anthropic-ai/claude-code
 
       - name: Install shellwright dependencies
-        if: github.event.action != 'closed'
+        if: github.event.action != 'closed' && steps.credentials.outputs.available == 'true'
         run: npm ci
 
       - name: Build shellwright
-        if: github.event.action != 'closed'
+        if: github.event.action != 'closed' && steps.credentials.outputs.available == 'true'
         run: npm run build
 
       - name: Install evaluation dependencies
-        if: github.event.action != 'closed'
+        if: github.event.action != 'closed' && steps.credentials.outputs.available == 'true'
         working-directory: evaluations
         run: npm install
 
       - name: Run evaluations
-        if: github.event.action != 'closed'
+        if: github.event.action != 'closed' && steps.credentials.outputs.available == 'true'
         working-directory: evaluations
         run: npm start
 
       - name: Generate comparison
-        if: github.event.action != 'closed'
+        if: github.event.action != 'closed' && steps.credentials.outputs.available == 'true'
         working-directory: evaluations
         env:
           GITHUB_REPOSITORY: ${{ github.repository }}
@@ -65,7 +82,7 @@ jobs:
         run: npm run compare
 
       - name: Deploy recordings to GitHub Pages
-        if: github.event.action != 'closed'
+        if: github.event.action != 'closed' && steps.credentials.outputs.available == 'true'
         uses: rossjrw/pr-preview-action@v1
         id: preview
         with:
@@ -86,7 +103,7 @@ jobs:
           comment: false
 
       - name: Comment with preview link
-        if: github.event.action != 'closed'
+        if: github.event.action != 'closed' && steps.credentials.outputs.available == 'true'
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           header: recording-eval
@@ -96,7 +113,7 @@ jobs:
             **[View Recordings & Review](${{ steps.preview.outputs.preview-url }})**
 
       - name: Upload recordings
-        if: github.event.action != 'closed'
+        if: github.event.action != 'closed' && steps.credentials.outputs.available == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: recordings

--- a/evaluations/README.md
+++ b/evaluations/README.md
@@ -7,7 +7,7 @@ Automated recording and screenshot evaluations using Claude API with shellwright
 ### Run evaluations locally
 
 ```bash
-# Requires ANTHROPIC_API_KEY
+# Requires ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN (from `claude setup-token`)
 npm run eval
 
 # Run a single scenario

--- a/evaluations/run.ts
+++ b/evaluations/run.ts
@@ -142,8 +142,9 @@ ${prompt}`,
 }
 
 async function main() {
-  if (!process.env.ANTHROPIC_API_KEY) {
-    console.error("Error: ANTHROPIC_API_KEY environment variable required");
+  // The Claude Agent SDK accepts an API key or a `claude setup-token` OAuth token
+  if (!process.env.ANTHROPIC_API_KEY && !process.env.CLAUDE_CODE_OAUTH_TOKEN) {
+    console.error("Error: ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN environment variable required");
     process.exit(1);
   }
 


### PR DESCRIPTION
## Summary
- Evals fail in CI because the `ANTHROPIC_API_KEY` secret's API account has no credits — every scenario returns "Credit balance is too low" and 0 tools are called (see run 29912984663).
- Wire `CLAUDE_CODE_OAUTH_TOKEN` (subscription auth from `claude setup-token`) into the eval workflow. The Claude CLI prefers `ANTHROPIC_API_KEY` when both are set, so the workflow only exposes the API key when no OAuth token is configured.
- Skip the eval steps gracefully (with a `::notice::`) when neither secret is available — e.g. fork PRs — instead of failing. The closed-PR preview cleanup step is unaffected.
- `evaluations/run.ts` now accepts either env var (the Agent SDK honors both).

## Setup
Generate a long-lived token from your Claude subscription and store it as a repo secret:

```bash
claude setup-token   # prints a long-lived OAuth token
gh secret set CLAUDE_CODE_OAUTH_TOKEN --repo dwmkerr/shellwright
```

Optionally delete the depleted API key secret: `gh secret delete ANTHROPIC_API_KEY --repo dwmkerr/shellwright` (not required — the workflow ignores it when the OAuth token is set).